### PR TITLE
Fix bug when sample_id not generated by VSN and values are cell ids for instance

### DIFF
--- a/bin/reports/sc_harmony_report.ipynb
+++ b/bin/reports/sc_harmony_report.ipynb
@@ -111,7 +111,8 @@
    "source": [
     "# Add by default sample_id as annotation to plot on top of the cell embeddings\n",
     "if \"sample_id\" in adata1.obs.keys() and \"sample_id\" in adata2.obs.keys():\n",
-    "    annotations_to_plot = annotations_to_plot if batch == \"sample_id\" else annotations_to_plot + [\"sample_id\"]"
+    "    if len(adata1.obs.sample_id) < 256 and len(adata2.obs.sample_id) < 256:\n",
+    "        annotations_to_plot = annotations_to_plot if batch == \"sample_id\" else annotations_to_plot + [\"sample_id\"]"
    ]
   },
   {


### PR DESCRIPTION
Only plot sample_id if values is less than 256